### PR TITLE
Fix mobile menu on other pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -117,6 +117,58 @@
   </div>
   <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
   <script>
+    // Mobile menu functionality
+    const navToggle = document.querySelector('.nav-toggle');
+    const navMenu = document.querySelector('.nav-menu');
+    const navOverlay = document.querySelector('.nav-overlay');
+    const navLinks = document.querySelectorAll('.nav-menu a');
+
+    function openMenu() {
+      navMenu.classList.add('active');
+      navToggle.classList.add('active');
+      navToggle.setAttribute('aria-expanded', 'true');
+      navOverlay.style.display = 'block';
+      document.body.style.overflow = 'hidden';
+    }
+    function closeMenu() {
+      navMenu.classList.remove('active');
+      navToggle.classList.remove('active');
+      navToggle.setAttribute('aria-expanded', 'false');
+      navOverlay.style.display = 'none';
+      document.body.style.overflow = '';
+    }
+    navToggle?.addEventListener('click', () => {
+      if (navMenu.classList.contains('active')) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+    navOverlay?.addEventListener('click', closeMenu);
+    navLinks.forEach(link => {
+      link.addEventListener('click', closeMenu);
+    });
+    document.addEventListener('keydown', (e) => {
+      if (navMenu.classList.contains('active') && e.key === 'Escape') {
+        closeMenu();
+      }
+    });
+    // Keyboard navigation for hamburger
+    navToggle?.addEventListener('keydown', (e) => {
+      if ((e.key === 'Enter' || e.key === ' ') && !navMenu.classList.contains('active')) {
+        openMenu();
+      } else if ((e.key === 'Enter' || e.key === ' ') && navMenu.classList.contains('active')) {
+        closeMenu();
+      }
+    });
+    // Highlight current page in nav
+    const currentPath = window.location.pathname.split('/').pop();
+    navLinks.forEach(link => {
+      if (link.getAttribute('href') === currentPath || (link.getAttribute('href') === 'index.html' && (currentPath === '' || currentPath === 'index.html'))) {
+        link.classList.add('active');
+      }
+    });
+
     document.addEventListener('DOMContentLoaded', function() {
       const calendlyModal = document.getElementById('calendlyModal');
       const calendlyModalClose = document.getElementById('calendlyModalClose');

--- a/about.html
+++ b/about.html
@@ -120,53 +120,9 @@
     // Mobile menu functionality
     const navToggle = document.querySelector('.nav-toggle');
     const navMenu = document.querySelector('.nav-menu');
-    const navOverlay = document.querySelector('.nav-overlay');
-    const navLinks = document.querySelectorAll('.nav-menu a');
-
-    function openMenu() {
-      navMenu.classList.add('active');
-      navToggle.classList.add('active');
-      navToggle.setAttribute('aria-expanded', 'true');
-      navOverlay.style.display = 'block';
-      document.body.style.overflow = 'hidden';
-    }
-    function closeMenu() {
-      navMenu.classList.remove('active');
-      navToggle.classList.remove('active');
-      navToggle.setAttribute('aria-expanded', 'false');
-      navOverlay.style.display = 'none';
-      document.body.style.overflow = '';
-    }
     navToggle?.addEventListener('click', () => {
-      if (navMenu.classList.contains('active')) {
-        closeMenu();
-      } else {
-        openMenu();
-      }
-    });
-    navOverlay?.addEventListener('click', closeMenu);
-    navLinks.forEach(link => {
-      link.addEventListener('click', closeMenu);
-    });
-    document.addEventListener('keydown', (e) => {
-      if (navMenu.classList.contains('active') && e.key === 'Escape') {
-        closeMenu();
-      }
-    });
-    // Keyboard navigation for hamburger
-    navToggle?.addEventListener('keydown', (e) => {
-      if ((e.key === 'Enter' || e.key === ' ') && !navMenu.classList.contains('active')) {
-        openMenu();
-      } else if ((e.key === 'Enter' || e.key === ' ') && navMenu.classList.contains('active')) {
-        closeMenu();
-      }
-    });
-    // Highlight current page in nav
-    const currentPath = window.location.pathname.split('/').pop();
-    navLinks.forEach(link => {
-      if (link.getAttribute('href') === currentPath || (link.getAttribute('href') === 'index.html' && (currentPath === '' || currentPath === 'index.html'))) {
-        link.classList.add('active');
-      }
+      navMenu.classList.toggle('active');
+      navToggle.classList.toggle('active');
     });
 
     document.addEventListener('DOMContentLoaded', function() {

--- a/contact.html
+++ b/contact.html
@@ -146,6 +146,58 @@
   </div>
   <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
   <script>
+    // Mobile menu functionality
+    const navToggle = document.querySelector('.nav-toggle');
+    const navMenu = document.querySelector('.nav-menu');
+    const navOverlay = document.querySelector('.nav-overlay');
+    const navLinks = document.querySelectorAll('.nav-menu a');
+
+    function openMenu() {
+      navMenu.classList.add('active');
+      navToggle.classList.add('active');
+      navToggle.setAttribute('aria-expanded', 'true');
+      navOverlay.style.display = 'block';
+      document.body.style.overflow = 'hidden';
+    }
+    function closeMenu() {
+      navMenu.classList.remove('active');
+      navToggle.classList.remove('active');
+      navToggle.setAttribute('aria-expanded', 'false');
+      navOverlay.style.display = 'none';
+      document.body.style.overflow = '';
+    }
+    navToggle?.addEventListener('click', () => {
+      if (navMenu.classList.contains('active')) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+    navOverlay?.addEventListener('click', closeMenu);
+    navLinks.forEach(link => {
+      link.addEventListener('click', closeMenu);
+    });
+    document.addEventListener('keydown', (e) => {
+      if (navMenu.classList.contains('active') && e.key === 'Escape') {
+        closeMenu();
+      }
+    });
+    // Keyboard navigation for hamburger
+    navToggle?.addEventListener('keydown', (e) => {
+      if ((e.key === 'Enter' || e.key === ' ') && !navMenu.classList.contains('active')) {
+        openMenu();
+      } else if ((e.key === 'Enter' || e.key === ' ') && navMenu.classList.contains('active')) {
+        closeMenu();
+      }
+    });
+    // Highlight current page in nav
+    const currentPath = window.location.pathname.split('/').pop();
+    navLinks.forEach(link => {
+      if (link.getAttribute('href') === currentPath || (link.getAttribute('href') === 'index.html' && (currentPath === '' || currentPath === 'index.html'))) {
+        link.classList.add('active');
+      }
+    });
+
     document.addEventListener('DOMContentLoaded', function() {
       const calendlyModal = document.getElementById('calendlyModal');
       const calendlyModalClose = document.getElementById('calendlyModalClose');

--- a/contact.html
+++ b/contact.html
@@ -149,53 +149,9 @@
     // Mobile menu functionality
     const navToggle = document.querySelector('.nav-toggle');
     const navMenu = document.querySelector('.nav-menu');
-    const navOverlay = document.querySelector('.nav-overlay');
-    const navLinks = document.querySelectorAll('.nav-menu a');
-
-    function openMenu() {
-      navMenu.classList.add('active');
-      navToggle.classList.add('active');
-      navToggle.setAttribute('aria-expanded', 'true');
-      navOverlay.style.display = 'block';
-      document.body.style.overflow = 'hidden';
-    }
-    function closeMenu() {
-      navMenu.classList.remove('active');
-      navToggle.classList.remove('active');
-      navToggle.setAttribute('aria-expanded', 'false');
-      navOverlay.style.display = 'none';
-      document.body.style.overflow = '';
-    }
     navToggle?.addEventListener('click', () => {
-      if (navMenu.classList.contains('active')) {
-        closeMenu();
-      } else {
-        openMenu();
-      }
-    });
-    navOverlay?.addEventListener('click', closeMenu);
-    navLinks.forEach(link => {
-      link.addEventListener('click', closeMenu);
-    });
-    document.addEventListener('keydown', (e) => {
-      if (navMenu.classList.contains('active') && e.key === 'Escape') {
-        closeMenu();
-      }
-    });
-    // Keyboard navigation for hamburger
-    navToggle?.addEventListener('keydown', (e) => {
-      if ((e.key === 'Enter' || e.key === ' ') && !navMenu.classList.contains('active')) {
-        openMenu();
-      } else if ((e.key === 'Enter' || e.key === ' ') && navMenu.classList.contains('active')) {
-        closeMenu();
-      }
-    });
-    // Highlight current page in nav
-    const currentPath = window.location.pathname.split('/').pop();
-    navLinks.forEach(link => {
-      if (link.getAttribute('href') === currentPath || (link.getAttribute('href') === 'index.html' && (currentPath === '' || currentPath === 'index.html'))) {
-        link.classList.add('active');
-      }
+      navMenu.classList.toggle('active');
+      navToggle.classList.toggle('active');
     });
 
     document.addEventListener('DOMContentLoaded', function() {

--- a/index.html
+++ b/index.html
@@ -269,53 +269,9 @@
   <script>
     const navToggle = document.querySelector('.nav-toggle');
     const navMenu = document.querySelector('.nav-menu');
-    const navOverlay = document.querySelector('.nav-overlay');
-    const navLinks = document.querySelectorAll('.nav-menu a');
-
-    function openMenu() {
-      navMenu.classList.add('active');
-      navToggle.classList.add('active');
-      navToggle.setAttribute('aria-expanded', 'true');
-      navOverlay.style.display = 'block';
-      document.body.style.overflow = 'hidden';
-    }
-    function closeMenu() {
-      navMenu.classList.remove('active');
-      navToggle.classList.remove('active');
-      navToggle.setAttribute('aria-expanded', 'false');
-      navOverlay.style.display = 'none';
-      document.body.style.overflow = '';
-    }
     navToggle?.addEventListener('click', () => {
-      if (navMenu.classList.contains('active')) {
-        closeMenu();
-      } else {
-        openMenu();
-      }
-    });
-    navOverlay?.addEventListener('click', closeMenu);
-    navLinks.forEach(link => {
-      link.addEventListener('click', closeMenu);
-    });
-    document.addEventListener('keydown', (e) => {
-      if (navMenu.classList.contains('active') && e.key === 'Escape') {
-        closeMenu();
-      }
-    });
-    // Keyboard navigation for hamburger
-    navToggle?.addEventListener('keydown', (e) => {
-      if ((e.key === 'Enter' || e.key === ' ') && !navMenu.classList.contains('active')) {
-        openMenu();
-      } else if ((e.key === 'Enter' || e.key === ' ') && navMenu.classList.contains('active')) {
-        closeMenu();
-      }
-    });
-    // Highlight current page in nav
-    const currentPath = window.location.pathname.split('/').pop();
-    navLinks.forEach(link => {
-      if (link.getAttribute('href') === currentPath || (link.getAttribute('href') === 'index.html' && (currentPath === '' || currentPath === 'index.html'))) {
-        link.classList.add('active');
-      }
+      navMenu.classList.toggle('active');
+      navToggle.classList.toggle('active');
     });
 
     // Scroll to top button

--- a/privacy.html
+++ b/privacy.html
@@ -143,53 +143,9 @@
     // Mobile menu functionality
     const navToggle = document.querySelector('.nav-toggle');
     const navMenu = document.querySelector('.nav-menu');
-    const navOverlay = document.querySelector('.nav-overlay');
-    const navLinks = document.querySelectorAll('.nav-menu a');
-
-    function openMenu() {
-      navMenu.classList.add('active');
-      navToggle.classList.add('active');
-      navToggle.setAttribute('aria-expanded', 'true');
-      navOverlay.style.display = 'block';
-      document.body.style.overflow = 'hidden';
-    }
-    function closeMenu() {
-      navMenu.classList.remove('active');
-      navToggle.classList.remove('active');
-      navToggle.setAttribute('aria-expanded', 'false');
-      navOverlay.style.display = 'none';
-      document.body.style.overflow = '';
-    }
     navToggle?.addEventListener('click', () => {
-      if (navMenu.classList.contains('active')) {
-        closeMenu();
-      } else {
-        openMenu();
-      }
-    });
-    navOverlay?.addEventListener('click', closeMenu);
-    navLinks.forEach(link => {
-      link.addEventListener('click', closeMenu);
-    });
-    document.addEventListener('keydown', (e) => {
-      if (navMenu.classList.contains('active') && e.key === 'Escape') {
-        closeMenu();
-      }
-    });
-    // Keyboard navigation for hamburger
-    navToggle?.addEventListener('keydown', (e) => {
-      if ((e.key === 'Enter' || e.key === ' ') && !navMenu.classList.contains('active')) {
-        openMenu();
-      } else if ((e.key === 'Enter' || e.key === ' ') && navMenu.classList.contains('active')) {
-        closeMenu();
-      }
-    });
-    // Highlight current page in nav
-    const currentPath = window.location.pathname.split('/').pop();
-    navLinks.forEach(link => {
-      if (link.getAttribute('href') === currentPath || (link.getAttribute('href') === 'index.html' && (currentPath === '' || currentPath === 'index.html'))) {
-        link.classList.add('active');
-      }
+      navMenu.classList.toggle('active');
+      navToggle.classList.toggle('active');
     });
 
     document.addEventListener('DOMContentLoaded', function() {

--- a/privacy.html
+++ b/privacy.html
@@ -140,6 +140,58 @@
   </div>
   <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
   <script>
+    // Mobile menu functionality
+    const navToggle = document.querySelector('.nav-toggle');
+    const navMenu = document.querySelector('.nav-menu');
+    const navOverlay = document.querySelector('.nav-overlay');
+    const navLinks = document.querySelectorAll('.nav-menu a');
+
+    function openMenu() {
+      navMenu.classList.add('active');
+      navToggle.classList.add('active');
+      navToggle.setAttribute('aria-expanded', 'true');
+      navOverlay.style.display = 'block';
+      document.body.style.overflow = 'hidden';
+    }
+    function closeMenu() {
+      navMenu.classList.remove('active');
+      navToggle.classList.remove('active');
+      navToggle.setAttribute('aria-expanded', 'false');
+      navOverlay.style.display = 'none';
+      document.body.style.overflow = '';
+    }
+    navToggle?.addEventListener('click', () => {
+      if (navMenu.classList.contains('active')) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+    navOverlay?.addEventListener('click', closeMenu);
+    navLinks.forEach(link => {
+      link.addEventListener('click', closeMenu);
+    });
+    document.addEventListener('keydown', (e) => {
+      if (navMenu.classList.contains('active') && e.key === 'Escape') {
+        closeMenu();
+      }
+    });
+    // Keyboard navigation for hamburger
+    navToggle?.addEventListener('keydown', (e) => {
+      if ((e.key === 'Enter' || e.key === ' ') && !navMenu.classList.contains('active')) {
+        openMenu();
+      } else if ((e.key === 'Enter' || e.key === ' ') && navMenu.classList.contains('active')) {
+        closeMenu();
+      }
+    });
+    // Highlight current page in nav
+    const currentPath = window.location.pathname.split('/').pop();
+    navLinks.forEach(link => {
+      if (link.getAttribute('href') === currentPath || (link.getAttribute('href') === 'index.html' && (currentPath === '' || currentPath === 'index.html'))) {
+        link.classList.add('active');
+      }
+    });
+
     document.addEventListener('DOMContentLoaded', function() {
       const calendlyModal = document.getElementById('calendlyModal');
       const calendlyModalClose = document.getElementById('calendlyModalClose');

--- a/program-models.html
+++ b/program-models.html
@@ -343,53 +343,9 @@
   <script>
     const navToggle = document.querySelector('.nav-toggle');
     const navMenu = document.querySelector('.nav-menu');
-    const navOverlay = document.querySelector('.nav-overlay');
-    const navLinks = document.querySelectorAll('.nav-menu a');
-
-    function openMenu() {
-      navMenu.classList.add('active');
-      navToggle.classList.add('active');
-      navToggle.setAttribute('aria-expanded', 'true');
-      navOverlay.style.display = 'block';
-      document.body.style.overflow = 'hidden';
-    }
-    function closeMenu() {
-      navMenu.classList.remove('active');
-      navToggle.classList.remove('active');
-      navToggle.setAttribute('aria-expanded', 'false');
-      navOverlay.style.display = 'none';
-      document.body.style.overflow = '';
-    }
     navToggle?.addEventListener('click', () => {
-      if (navMenu.classList.contains('active')) {
-        closeMenu();
-      } else {
-        openMenu();
-      }
-    });
-    navOverlay?.addEventListener('click', closeMenu);
-    navLinks.forEach(link => {
-      link.addEventListener('click', closeMenu);
-    });
-    document.addEventListener('keydown', (e) => {
-      if (navMenu.classList.contains('active') && e.key === 'Escape') {
-        closeMenu();
-      }
-    });
-    // Keyboard navigation for hamburger
-    navToggle?.addEventListener('keydown', (e) => {
-      if ((e.key === 'Enter' || e.key === ' ') && !navMenu.classList.contains('active')) {
-        openMenu();
-      } else if ((e.key === 'Enter' || e.key === ' ') && navMenu.classList.contains('active')) {
-        closeMenu();
-      }
-    });
-    // Highlight current page in nav
-    const currentPath = window.location.pathname.split('/').pop();
-    navLinks.forEach(link => {
-      if (link.getAttribute('href') === currentPath || (link.getAttribute('href') === 'index.html' && (currentPath === '' || currentPath === 'index.html'))) {
-        link.classList.add('active');
-      }
+      navMenu.classList.toggle('active');
+      navToggle.classList.toggle('active');
     });
   </script>
 

--- a/terms.html
+++ b/terms.html
@@ -156,53 +156,9 @@
     // Mobile menu functionality
     const navToggle = document.querySelector('.nav-toggle');
     const navMenu = document.querySelector('.nav-menu');
-    const navOverlay = document.querySelector('.nav-overlay');
-    const navLinks = document.querySelectorAll('.nav-menu a');
-
-    function openMenu() {
-      navMenu.classList.add('active');
-      navToggle.classList.add('active');
-      navToggle.setAttribute('aria-expanded', 'true');
-      navOverlay.style.display = 'block';
-      document.body.style.overflow = 'hidden';
-    }
-    function closeMenu() {
-      navMenu.classList.remove('active');
-      navToggle.classList.remove('active');
-      navToggle.setAttribute('aria-expanded', 'false');
-      navOverlay.style.display = 'none';
-      document.body.style.overflow = '';
-    }
     navToggle?.addEventListener('click', () => {
-      if (navMenu.classList.contains('active')) {
-        closeMenu();
-      } else {
-        openMenu();
-      }
-    });
-    navOverlay?.addEventListener('click', closeMenu);
-    navLinks.forEach(link => {
-      link.addEventListener('click', closeMenu);
-    });
-    document.addEventListener('keydown', (e) => {
-      if (navMenu.classList.contains('active') && e.key === 'Escape') {
-        closeMenu();
-      }
-    });
-    // Keyboard navigation for hamburger
-    navToggle?.addEventListener('keydown', (e) => {
-      if ((e.key === 'Enter' || e.key === ' ') && !navMenu.classList.contains('active')) {
-        openMenu();
-      } else if ((e.key === 'Enter' || e.key === ' ') && navMenu.classList.contains('active')) {
-        closeMenu();
-      }
-    });
-    // Highlight current page in nav
-    const currentPath = window.location.pathname.split('/').pop();
-    navLinks.forEach(link => {
-      if (link.getAttribute('href') === currentPath || (link.getAttribute('href') === 'index.html' && (currentPath === '' || currentPath === 'index.html'))) {
-        link.classList.add('active');
-      }
+      navMenu.classList.toggle('active');
+      navToggle.classList.toggle('active');
     });
 
     document.addEventListener('DOMContentLoaded', function() {

--- a/terms.html
+++ b/terms.html
@@ -153,6 +153,58 @@
   </div>
   <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js" async></script>
   <script>
+    // Mobile menu functionality
+    const navToggle = document.querySelector('.nav-toggle');
+    const navMenu = document.querySelector('.nav-menu');
+    const navOverlay = document.querySelector('.nav-overlay');
+    const navLinks = document.querySelectorAll('.nav-menu a');
+
+    function openMenu() {
+      navMenu.classList.add('active');
+      navToggle.classList.add('active');
+      navToggle.setAttribute('aria-expanded', 'true');
+      navOverlay.style.display = 'block';
+      document.body.style.overflow = 'hidden';
+    }
+    function closeMenu() {
+      navMenu.classList.remove('active');
+      navToggle.classList.remove('active');
+      navToggle.setAttribute('aria-expanded', 'false');
+      navOverlay.style.display = 'none';
+      document.body.style.overflow = '';
+    }
+    navToggle?.addEventListener('click', () => {
+      if (navMenu.classList.contains('active')) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+    navOverlay?.addEventListener('click', closeMenu);
+    navLinks.forEach(link => {
+      link.addEventListener('click', closeMenu);
+    });
+    document.addEventListener('keydown', (e) => {
+      if (navMenu.classList.contains('active') && e.key === 'Escape') {
+        closeMenu();
+      }
+    });
+    // Keyboard navigation for hamburger
+    navToggle?.addEventListener('keydown', (e) => {
+      if ((e.key === 'Enter' || e.key === ' ') && !navMenu.classList.contains('active')) {
+        openMenu();
+      } else if ((e.key === 'Enter' || e.key === ' ') && navMenu.classList.contains('active')) {
+        closeMenu();
+      }
+    });
+    // Highlight current page in nav
+    const currentPath = window.location.pathname.split('/').pop();
+    navLinks.forEach(link => {
+      if (link.getAttribute('href') === currentPath || (link.getAttribute('href') === 'index.html' && (currentPath === '' || currentPath === 'index.html'))) {
+        link.classList.add('active');
+      }
+    });
+
     document.addEventListener('DOMContentLoaded', function() {
       const calendlyModal = document.getElementById('calendlyModal');
       const calendlyModalClose = document.getElementById('calendlyModalClose');


### PR DESCRIPTION
Implement working mobile menu functionality on several pages that were missing the required JavaScript.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9e63b61-b058-4f67-9e47-be10af5afb41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9e63b61-b058-4f67-9e47-be10af5afb41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>